### PR TITLE
Add cygwin support

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,4 +1,4 @@
-use lib inc; use Devel::AssertOS qw(Linux FreeBSD DragonflyBSD OpenBSD MacOSX NetBSD);
+use lib inc; use Devel::AssertOS qw(Cygwin Linux FreeBSD DragonflyBSD OpenBSD MacOSX NetBSD);
 
 use strict;
 use warnings;
@@ -26,7 +26,7 @@ my $build = Module::Build->new(
     meta_merge => {
         resources => {
             repository => 'https://github.com/pioto/Unix-Uptime',
-            license => 'http://dev.perl.org/licenses/',
+            license => ['http://dev.perl.org/licenses/'],
             bugtracker => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Unix-Uptime',
         },
     },

--- a/Build.PL
+++ b/Build.PL
@@ -26,7 +26,6 @@ my $build = Module::Build->new(
     meta_merge => {
         resources => {
             repository => 'https://github.com/pioto/Unix-Uptime',
-            license => ['http://dev.perl.org/licenses/'],
             bugtracker => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Unix-Uptime',
         },
     },

--- a/inc/Devel/AssertOS.pm
+++ b/inc/Devel/AssertOS.pm
@@ -1,7 +1,4 @@
-# $Id: AssertOS.pm,v 1.5 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS;
+package Devel::AssertOS;
 
 use Devel::CheckOS;
 
@@ -9,7 +6,7 @@ use strict;
 
 use vars qw($VERSION);
 
-$VERSION = '1.1';
+$VERSION = '1.21';
 
 # localising prevents the warningness leaking out of this module
 local $^W = 1;    # use warnings is a 5.6-ism
@@ -29,12 +26,33 @@ do this:
 which will die unless the platform the code is running on is Linux, FreeBSD
 or Cygwin.
 
+To assert that the OS is B<not> a specific platform, prepend the platform name
+with a minus sign. For example, to run on anything but Amiga, do:
+
+    use Devel::AssertOS qw(-Amiga);
+
+
 =cut
 
 sub import {
     shift;
     die("Devel::AssertOS needs at least one parameter\n") unless(@_);
-    Devel::CheckOS::die_if_os_isnt(@_);
+
+    my @oses = @_;
+
+    my ( @must, @must_not );
+
+    for my $os ( @oses ) {
+        if ( $os =~ s/^-// ) {
+            push @must_not, $os;
+        }
+        else {
+            push @must, $os;
+        }
+    }
+
+    Devel::CheckOS::die_if_os_is(@must_not) if @must_not;
+    Devel::CheckOS::die_if_os_isnt(@must)   if @must;
 }
 
 =head1 BUGS and FEEDBACK

--- a/inc/Devel/AssertOS/AIX.pm
+++ b/inc/Devel/AssertOS/AIX.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::AIX;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^aix$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Amiga.pm
+++ b/inc/Devel/AssertOS/Amiga.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Amiga;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^amigaos$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Android.pm
+++ b/inc/Devel/AssertOS/Android.pm
@@ -1,0 +1,11 @@
+package Devel::AssertOS::Android;
+
+use Devel::CheckOS;
+
+$VERSION = '1.2';
+
+sub os_is { $^O =~ /^android$/i ? 1 : 0; }
+
+Devel::CheckOS::die_unsupported() unless(os_is());
+
+1;

--- a/inc/Devel/AssertOS/Apple.pm
+++ b/inc/Devel/AssertOS/Apple.pm
@@ -1,16 +1,20 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: Apple.pm,v 1.5 2008/11/05 22:52:34 drhyde Exp $
+
+package Devel::AssertOS::Apple;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(MacOSX MacOSclassis); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn { "The operating system is from Apple" }
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/BSDOS.pm
+++ b/inc/Devel/AssertOS/BSDOS.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::BSDOS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^bsdos$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/BeOS.pm
+++ b/inc/Devel/AssertOS/BeOS.pm
@@ -1,0 +1,36 @@
+package Devel::AssertOS::BeOS;
+
+use Devel::CheckOS;
+
+$VERSION = '1.4';
+
+# weird special case, not quite like other OS modules, as this is both
+# an OS *and* a family - maybe this should be fixed at some point
+sub matches { return qw(Haiku) }
+sub os_is {
+    return 1 if(
+        $^O =~ /^beos$/i ||
+        Devel::CheckOS::os_is('Haiku')
+    );
+    return 0;
+}
+
+sub expn {
+join("\n",
+"This matches both Be Inc's original BeOS, as well as Haiku, an open-",
+"source BeOS-compatible project.  This is because Haiku is intended",
+"to be able to run BeOS software, while also having its own extra features."
+)
+}
+
+Devel::CheckOS::die_unsupported() unless(os_is());
+
+=head1 COPYRIGHT and LICENCE
+
+Copyright 2007 - 2014 David Cantrell
+
+This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
+
+=cut
+
+1;

--- a/inc/Devel/AssertOS/Bitrig.pm
+++ b/inc/Devel/AssertOS/Bitrig.pm
@@ -1,16 +1,16 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Bitrig;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.0';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^BITRIG$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Cygwin.pm
+++ b/inc/Devel/AssertOS/Cygwin.pm
@@ -1,10 +1,17 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Cygwin;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^cygwin$/i ? 1 : 0; }
+
+sub expn {
+join("\n",
+"The operating system is Microsoft Windows, but perl was built using",
+"the POSIXish API provided by Cygwin"
+)
+}
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/DEC.pm
+++ b/inc/Devel/AssertOS/DEC.pm
@@ -1,16 +1,25 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: DEC.pm,v 1.5 2008/11/05 22:52:34 drhyde Exp $
+
+package Devel::AssertOS::DEC;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.4';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(OSF VMS); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn {
+join("\n",
+"The operating system is from Digital Equipment Corporation, or was",
+"originally written by DEC before they were taken over by Compaq/HP"
+)
+}
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/DGUX.pm
+++ b/inc/Devel/AssertOS/DGUX.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::DGUX;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^dgux$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Darwin.pm~
+++ b/inc/Devel/AssertOS/Darwin.pm~
@@ -1,0 +1,13 @@
+# $Id: Darwin.pm~,v 1.1 2007/10/02 09:48:54 drhyde Exp $
+
+package Devel::AssertOS::Darwin;
+
+use Devel::CheckOS qw(die_unsupported);
+
+$VERSION = '1.0';
+
+sub os_is { $^O eq 'darwin' ? 1 : 0; }
+
+die_unsupported() unless(os_is());
+
+1;

--- a/inc/Devel/AssertOS/DragonflyBSD.pm
+++ b/inc/Devel/AssertOS/DragonflyBSD.pm
@@ -1,19 +1,16 @@
-# $Id: DragonflyBSD.pm,v 1.3 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::DragonflyBSD;
+package Devel::AssertOS::DragonflyBSD;
 
 use Devel::CheckOS;
 
-$VERSION = '1.1';
+$VERSION = '1.2';
 
-sub os_is { $^O eq 'dragonfly' ? 1 : 0; }
+sub os_is { $^O =~ /^dragonfly$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Dynix.pm
+++ b/inc/Devel/AssertOS/Dynix.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Dynix;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^dynixptx$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/EBCDIC.pm
+++ b/inc/Devel/AssertOS/EBCDIC.pm
@@ -1,16 +1,26 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::EBCDIC;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.0';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+# list of OSes lifted from Module::Build 0.2808
+#
+sub matches {
+    return qw(
+        OS390 OS400 POSIXBC VMESA
+    );
+}
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn {
+  "The OS uses some variant of EBCDIC instead of ASCII."
+}
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2010 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Extending.pod
+++ b/inc/Devel/AssertOS/Extending.pod
@@ -1,0 +1,123 @@
+=head1 NAME
+
+Devel::AssertOS::Extending - how to write Devel::AssertOS::* modules that
+check what platform they're running on
+
+=head1 DESCRIPTION
+
+Devel::AssertOS::* modules are used by Devel::CheckOS to figure out what
+OS it is running on.  A set of modules are provided which should correctly
+detect all platforms that perl *currently* runs on, as well as detecting
+OS 'families' like 'Unix' and 'Windows'.
+
+You can also use Devel::AssertOS::* modules on their own to quickly check
+whether you're running on the right platform.
+
+If you try to C<use> a Devel::AssertOS module on the wrong platform, it
+will C<die> by calling C<Devel::CheckOS::die_unsupported()>.  This
+conveniently spits out the text that CPAN-testers look for to see if
+your code failed simply because they're doing something as silly as
+testing your Solaris-only code on HPUX.
+
+=head1 HOW TO WRITE YOUR OWN MODULES
+
+If you want to add support for new platforms, you need to write a module
+called Devel::AssertOS::PlatformName which looks like:
+
+    package Devel::AssertOS::Linux;
+    use Devel::CheckOS;
+    $VERSION = '1.0';
+    sub os_is { $^O =~ /^linux$/i ? 1 : 0; }
+    Devel::CheckOS::die_unsupported() unless(os_is());
+    1;
+
+And that's it.  The subroutine B<must> be called C<os_is> and loading the
+module B<must> die in precisely that manner if your code is running on
+the wrong platform. It's a good idea to check $^O case-insensitively
+as it's not consistent. Note that it is an error to say:
+
+    sub os_is { 1; }
+
+and assume "well, on the wrong platform that'll never get reached because
+the module can't load".  Because the module *can* load, and indeed *does
+get loaded* - some functions in Devel::CheckOS do things like:
+
+    eval "use Devel::AssertOS::$os";
+
+to suppress the error.
+
+If you want to support a 'family' of OSes, then instead of matching against
+C<$^O>, instead use C<Devel::CheckOS::os_is> to check that we're running on
+any of the OSes in your family, like this:
+
+match any of several values of C<$^O> like this:
+
+    package Devel::AssertOS::FreeSoftware;
+    use Devel::CheckOS;
+    $VERSION = '1.0';
+    sub matches { return qw(Linux FreeBSD NetBSD OpenBSD DragonflyBSD); }
+    sub os_is { Devel::CheckOS::os_is(matches()); }
+    sub expn { "The operating system is free-as-in-beer" }
+    Devel::CheckOS::die_unsupported() unless(os_is());
+
+You may also add a subroutine called C<expn> which should return a small
+snippet of explanatory text.  Again, see Devel::AssertOS::Unix for an
+example.  This is particularly useful for 'family' modules.
+
+Note the C<matches> subroutine - this is so that people can query your
+module and see what OSes are in your family.
+
+=head1 VERSIONS OF AN OS
+
+Two levels of name are supported.  So C<Devel::AssertOS::Linux::v2_6> is
+legal.  More than two levels are not supported.  Be careful to pick names
+that are both legal perl package names and legal filenames on all platforms.
+In general, this means anything that matches C</[_a-z]\w*/i>.
+
+=head1 OS FEATURES
+
+I would like to reserve the namespace C<Devel::AssertOS::OSFeatures::*>.
+If you want to release a module that tells the user whether a particular
+feature is available (eg, whether POSIX shell redirection can be expected
+to work) then please discuss it with me first.
+
+=head1 BUGS and FEEDBACK
+
+I welcome feedback about my code, including constructive criticism.
+Bug reports should be made using L<http://rt.cpan.org/> or by email.
+
+If you are feeling particularly generous you can encourage me in my
+open source endeavours by buying me something from my wishlist:
+  L<http://www.cantrell.org.uk/david/wishlist/>
+
+=head1 SEE ALSO
+
+L<Devel::CheckOS>
+
+$^O in L<perlvar>
+
+L<perlport>
+
+=head1 AUTHOR
+
+David Cantrell E<lt>F<david@cantrell.org.uk>E<gt>
+
+Thanks to David Golden for the name and ideas about the interface, and
+for the cpan-testers-discuss mailing list for prompting me to write it
+in the first place.
+
+=head1 COPYRIGHT and LICENCE
+
+Copyright 2007 - 2014 David Cantrell
+
+This documentation is free-as-in-speech.  It may be used,
+distributed and modified under the terms of the Creative Commons
+Attribution-Share Alike 2.0 UK: England & Wales License, whose
+text you may read at
+L<http://creativecommons.org/licenses/by-sa/2.0/uk/>.
+
+=head1 CONSPIRACY
+
+This documentation is also free-as-in-mason.
+
+=cut

--- a/inc/Devel/AssertOS/FreeBSD.pm
+++ b/inc/Devel/AssertOS/FreeBSD.pm
@@ -1,19 +1,16 @@
-# $Id: FreeBSD.pm,v 1.5 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::FreeBSD;
+package Devel::AssertOS::FreeBSD;
 
 use Devel::CheckOS;
 
-$VERSION = '1.0';
+$VERSION = '1.2';
 
-sub os_is { $^O eq 'freebsd' ? 1 : 0; }
+sub os_is { $^O =~ /^(gnuk)?freebsd$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/GNUkFreeBSD.pm
+++ b/inc/Devel/AssertOS/GNUkFreeBSD.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::GNUkFreeBSD;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^gnukfreebsd$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/HPUX.pm
+++ b/inc/Devel/AssertOS/HPUX.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::HPUX;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^hpux$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Haiku.pm
+++ b/inc/Devel/AssertOS/Haiku.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Haiku;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^haiku$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Interix.pm
+++ b/inc/Devel/AssertOS/Interix.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Interix;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^interix$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Irix.pm
+++ b/inc/Devel/AssertOS/Irix.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Irix;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^irix$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Linux.pm
+++ b/inc/Devel/AssertOS/Linux.pm
@@ -1,19 +1,30 @@
-# $Id: Linux.pm,v 1.5 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::Linux;
+package Devel::AssertOS::Linux;
 
 use Devel::CheckOS;
 
-$VERSION = '1.1';
+$VERSION = '1.3';
 
-sub os_is { $^O eq 'linux' ? 1 : 0; }
+
+sub subtypes { qw(Android) }
+sub matches { ('Linux', subtypes()) }
+
+sub os_is {
+    (
+        # order is important
+        Devel::CheckOS::os_is(subtypes()) ||
+        $^O =~ /^linux$/i
+    ) ? 1 : 0;
+}
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
+sub expn {
+    "The operating system has a Linux kernel"
+}
+
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Linux/v2_6.pm
+++ b/inc/Devel/AssertOS/Linux/v2_6.pm
@@ -1,16 +1,23 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: v2_6.pm,v 1.4 2008/11/05 22:52:35 drhyde Exp $
+
+package Devel::AssertOS::Linux::v2_6;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is {
+    Devel::CheckOS::os_is('Linux') &&
+    `uname -r` =~ /^2\.6\./ ? 1 : 0;
+}
+
+sub expn { "The operating system has a Linux 2.6.x series kernel" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/MPEiX.pm
+++ b/inc/Devel/AssertOS/MPEiX.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MPEiX;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^mpeix$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MSDOS.pm
+++ b/inc/Devel/AssertOS/MSDOS.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MSDOS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^dos$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MSWin32.pm
+++ b/inc/Devel/AssertOS/MSWin32.pm
@@ -1,10 +1,17 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MSWin32;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^MSWin32$/i ? 1 : 0; }
+
+sub expn {
+join("\n",
+"The operating system is Microsoft Windows, and perl was built using",
+"the Win32 API"
+)
+}
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MacOSX.pm
+++ b/inc/Devel/AssertOS/MacOSX.pm
@@ -1,19 +1,16 @@
-# $Id: MacOSX.pm,v 1.3 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::MacOSX;
+package Devel::AssertOS::MacOSX;
 
 use Devel::CheckOS;
 
-$VERSION = '1.1';
+$VERSION = '1.2';
 
-sub os_is { $^O eq 'darwin' ? 1 : 0; }
+sub os_is { $^O =~ /^darwin$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/MacOSX/v10_4.pm
+++ b/inc/Devel/AssertOS/MacOSX/v10_4.pm
@@ -1,16 +1,23 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: v10_4.pm,v 1.4 2008/11/05 22:52:35 drhyde Exp $
+
+package Devel::AssertOS::MacOSX::v10_4;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is {
+    Devel::CheckOS::os_is('MacOSX') &&
+    `sw_vers -productVersion` =~ /^10\.4\./ ? 1 : 0;
+}
+
+sub expn { "The operating system is some version of OS X Tiger (10.4)" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/MacOSX/v10_5.pm
+++ b/inc/Devel/AssertOS/MacOSX/v10_5.pm
@@ -1,16 +1,21 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MacOSX::v10_5;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.0';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is {
+    Devel::CheckOS::os_is('MacOSX') &&
+    `sw_vers -productVersion` =~ /^10\.5\./ ? 1 : 0;
+}
+
+sub expn { "The operating system is some version of OS X Leopard (10.5)" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/MacOSclassic.pm
+++ b/inc/Devel/AssertOS/MacOSclassic.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MacOSclassic;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^MacOS$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MachTen.pm
+++ b/inc/Devel/AssertOS/MachTen.pm
@@ -1,10 +1,17 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MachTen;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^machten$/i ? 1 : 0; }
+
+sub expn {
+join("\n",
+"You're using the Mach Ten BSD-compatible environment on top of",
+"Mac OS 'Classic' - ie, a pre-OS-X version of Mac OS.",
+)
+}
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MicrosoftWindows.pm
+++ b/inc/Devel/AssertOS/MicrosoftWindows.pm
@@ -1,16 +1,20 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: MicrosoftWindows.pm,v 1.6 2008/11/05 22:52:34 drhyde Exp $
+
+package Devel::AssertOS::MicrosoftWindows;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(Cygwin MSWin32); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn { "The operating system is some version of Microsoft Windows" }
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/MidnightBSD.pm
+++ b/inc/Devel/AssertOS/MidnightBSD.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MidnightBSD;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^midnightbsd$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/MirOSBSD.pm
+++ b/inc/Devel/AssertOS/MirOSBSD.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::MirOSBSD;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^mirbsd$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/NeXT.pm
+++ b/inc/Devel/AssertOS/NeXT.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::NeXT;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^next$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/NetBSD.pm
+++ b/inc/Devel/AssertOS/NetBSD.pm
@@ -1,19 +1,16 @@
-# $Id: NetBSD.pm,v 1.3 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::NetBSD;
+package Devel::AssertOS::NetBSD;
 
 use Devel::CheckOS;
 
-$VERSION = '1.1';
+$VERSION = '1.2';
 
-sub os_is { $^O eq 'netbsd' ? 1 : 0; }
+sub os_is { $^O =~ /^netbsd$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Netware.pm
+++ b/inc/Devel/AssertOS/Netware.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Netware;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^netware$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/OS2.pm
+++ b/inc/Devel/AssertOS/OS2.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::OS2;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^os2$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/OS390.pm
+++ b/inc/Devel/AssertOS/OS390.pm
@@ -1,10 +1,12 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::OS390;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^os390$/i ? 1 : 0; }
+
+sub expn { "OS390 is also known as z/OS" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/OS400.pm
+++ b/inc/Devel/AssertOS/OS400.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::OS400;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^os400$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/OSF.pm
+++ b/inc/Devel/AssertOS/OSF.pm
@@ -1,10 +1,12 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::OSF;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^dec_osf$/i ? 1 : 0; }
+
+sub expn { "OSF is also known as OSF/1, Digital Unix, and Tru64 Unix" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/OSFeatures/POSIXShellRedirection.pm
+++ b/inc/Devel/AssertOS/OSFeatures/POSIXShellRedirection.pm
@@ -1,0 +1,43 @@
+# $Id: POSIXShellRedirection.pm,v 1.3 2008/11/05 22:52:35 drhyde Exp $
+
+package Devel::AssertOS::OSFeatures::POSIXShellRedirection;
+
+$VERSION = '1.4';
+
+use Devel::CheckOS;
+
+sub matches { return qw(Unix Cygwin BeOS VOS); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
+Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn {
+join("\n",
+"The operating system's normal shell(s) support POSIX-style redirection",
+"such as:",
+"  foo |  more    (piping from one command to another)",
+"  foo >  file    (redirection of STDOUT to a file)",
+"  foo 2> file    (redirection of STDERR to a file)",
+"  foo <  file    (redirection of STDIN from a file)",
+"and so on"
+)
+}
+
+=head1 NAME
+
+Devel::AssertOS::OSFeatures::POSIXShellRedirection - check whether
+the OS we're running on can be expected to support POSIX shell
+redirection.
+
+=head1 SYNOPSIS
+
+See L<Devel::CheckOS> and L<Devel::AssertOS>
+
+=head1 COPYRIGHT and LICENCE
+
+Copyright 2007 - 2008 David Cantrell
+
+This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
+
+=cut
+
+1;

--- a/inc/Devel/AssertOS/POSIXBC.pm
+++ b/inc/Devel/AssertOS/POSIXBC.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::POSIXBC;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^posix-bc$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/QNX.pm
+++ b/inc/Devel/AssertOS/QNX.pm
@@ -1,16 +1,24 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: QNX.pm,v 1.2 2008/10/27 20:31:21 drhyde Exp $
+
+package Devel::AssertOS::QNX;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(QNX::v4 QNX::Neutrino); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
+sub expn {
+join("\n", 
+"All versions of QNX match this, as well as (possibly) a more specific",
+"match"
+)
+}
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/QNX/Neutrino.pm
+++ b/inc/Devel/AssertOS/QNX/Neutrino.pm
@@ -1,10 +1,12 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::QNX::Neutrino;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^nto$/i ? 1 : 0; }
+
+sub expn { "The operating system is version 6 of QNX, also known as Neutrino" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/QNX/v4.pm
+++ b/inc/Devel/AssertOS/QNX/v4.pm
@@ -1,10 +1,12 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::QNX::v4;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.1';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^qnx$/i ? 1 : 0; }
+
+sub expn { "The operating system is version 4 of QNX" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/RISCOS.pm
+++ b/inc/Devel/AssertOS/RISCOS.pm
@@ -1,10 +1,12 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::RISCOS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^riscos$/i ? 1 : 0; }
+
+sub expn { "This is the Acorn operating system, not the MIPS RISC/os system" }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Realtime.pm
+++ b/inc/Devel/AssertOS/Realtime.pm
@@ -1,16 +1,20 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: Realtime.pm,v 1.3 2008/11/05 22:52:34 drhyde Exp $
+
+package Devel::AssertOS::Realtime;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(QNX); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn { "This is a realtime operating system" }
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/SCO.pm
+++ b/inc/Devel/AssertOS/SCO.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::SCO;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^sco_sv$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Solaris.pm
+++ b/inc/Devel/AssertOS/Solaris.pm
@@ -1,19 +1,16 @@
-# $Id: Solaris.pm,v 1.3 2008/10/27 20:31:21 drhyde Exp $
-
-package #
-Devel::AssertOS::Solaris;
+package Devel::AssertOS::Solaris;
 
 use Devel::CheckOS;
 
-$VERSION = '1.1';
+$VERSION = '1.2';
 
-sub os_is { $^O eq 'solaris' ? 1 : 0; }
+sub os_is { $^O =~ /^solaris$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2008 David Cantrell
+Copyright 2007 - 2014 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/Sun.pm
+++ b/inc/Devel/AssertOS/Sun.pm
@@ -1,16 +1,20 @@
-package Devel::AssertOS::OpenBSD;
+# $Id: Sun.pm,v 1.5 2008/11/05 22:52:34 drhyde Exp $
+
+package Devel::AssertOS::Sun;
 
 use Devel::CheckOS;
 
-$VERSION = '1.2';
+$VERSION = '1.3';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
-
+sub matches { return qw(SunOS Solaris); }
+sub os_is { Devel::CheckOS::os_is(matches()); }
 Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn { "The operating system is from Sun Microsystems" }
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007 - 2014 David Cantrell
+Copyright 2007 - 2008 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/AssertOS/SunOS.pm
+++ b/inc/Devel/AssertOS/SunOS.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::SunOS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^sunos$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/SysVr4.pm
+++ b/inc/Devel/AssertOS/SysVr4.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::SysVr4;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^svr4$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/SysVr5.pm
+++ b/inc/Devel/AssertOS/SysVr5.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::SysVr5;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^svr5$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Unicos.pm
+++ b/inc/Devel/AssertOS/Unicos.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::Unicos;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^unicos(mk)?$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/Unix.pm
+++ b/inc/Devel/AssertOS/Unix.pm
@@ -1,0 +1,37 @@
+package Devel::AssertOS::Unix;
+
+use Devel::CheckOS;
+
+$VERSION = '1.5';
+
+# list of OSes originally lifted from Module::Build 0.2808
+#
+sub matches {
+    return qw(
+        AIX Android Bitrig BSDOS DGUX DragonflyBSD Dynix FreeBSD HPUX Interix Irix
+        Linux MachTen MacOSX MirOSBSD NetBSD OpenBSD OSF QNX SCO Solaris
+        SunOS SysVr4 SysVr5 Unicos MidnightBSD
+    );
+}
+sub os_is { Devel::CheckOS::os_is(matches()); }
+Devel::CheckOS::die_unsupported() unless(os_is());
+
+sub expn {
+join("\n", 
+"The OS supports multiple concurrent users, devices are represented as",
+"pseudo-files in /dev, there is a single root to the filesystem, users",
+"are protected from interference from other users, and the API is POSIXy.",
+"It should be reasonably easy to port a simple text-mode C program",
+"between Unixes."
+)
+}
+
+=head1 COPYRIGHT and LICENCE
+
+Copyright 2007 - 2014 David Cantrell
+
+This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
+
+=cut
+
+1;

--- a/inc/Devel/AssertOS/VMESA.pm
+++ b/inc/Devel/AssertOS/VMESA.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::VMESA;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^vmesa$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/VMS.pm
+++ b/inc/Devel/AssertOS/VMS.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::VMS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^VMS$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/AssertOS/VOS.pm
+++ b/inc/Devel/AssertOS/VOS.pm
@@ -1,10 +1,10 @@
-package Devel::AssertOS::OpenBSD;
+package Devel::AssertOS::VOS;
 
 use Devel::CheckOS;
 
 $VERSION = '1.2';
 
-sub os_is { $^O =~ /^openbsd$/i ? 1 : 0; }
+sub os_is { $^O =~ /^vos$/i ? 1 : 0; }
 
 Devel::CheckOS::die_unsupported() unless(os_is());
 

--- a/inc/Devel/CheckOS.pm
+++ b/inc/Devel/CheckOS.pm
@@ -1,12 +1,11 @@
-package #
-Devel::CheckOS;
+package Devel::CheckOS;
 
 use strict;
 use Exporter;
 
 use vars qw($VERSION @ISA @EXPORT_OK %EXPORT_TAGS);
 
-$VERSION = '1.63';
+$VERSION = '1.73';
 
 # localising prevents the warningness leaking out of this module
 local $^W = 1;    # use warnings is a 5.6-ism
@@ -307,13 +306,20 @@ Thanks to Matt Kraai for information about QNX.
 Thanks to Kenichi Ishigaki and Gabor Szabo for reporting a bug on Windows,
 and to the former for providing a patch.
 
+Thanks to Paul Green for some information about VOS.
+
+Thanks to Yanick Champoux for a patch to let Devel::AssertOS support
+negative assertions.
+
+Thanks to Brian Fraser for adding Android support.
+
 =head1 SOURCE CODE REPOSITORY
 
-L<http://www.cantrell.org.uk/cgit/cgit.cgi/perlmodules/>
+L<git://github.com/DrHyde/perl-modules-Devel-CheckOS.git>
 
 =head1 COPYRIGHT and LICENCE
 
-Copyright 2007-2009 David Cantrell
+Copyright 2007-2012 David Cantrell
 
 This software is free-as-in-speech software, and may be used, distributed, and modified under the terms of either the GNU General Public Licence version 2 or the Artistic Licence. It's up to you which one you use. The full text of the licences can be found in the files GPL2.txt and ARTISTIC.txt, respectively.
 

--- a/inc/Devel/CheckOS/Families.pod
+++ b/inc/Devel/CheckOS/Families.pod
@@ -1,0 +1,73 @@
+=head1 NAME
+
+Devel::CheckOS::Families - what OS "families" are supported "out of the
+box" by Devel::CheckOS and Devel::AssertOS?
+
+=head1 WHAT IS AN OS FAMILY
+
+Computing platforms fall into several categories.  For example, there is
+the category of Unix-a-likes.  Each of these categories is a "family".
+A platform can fall into several families.
+
+=head1 THE Unix FAMILY
+
+Broadly speaking, these are platforms where:
+
+=over
+
+=item Devices are represented as pseudo-files in the filesystem
+
+=item Symlinks and hardlinks are supported in at least some filesystems
+
+=item "Unix-style" permissions are supported
+
+That is, there are seperate read/write/execute permissions for file owner,
+group and anyone.  This implies the presence of multiple user accounts
+and user groups.  Permissions may not be supported on all filesystems.
+
+=item The filesystem has a single root
+
+=item The C API for the operating system is largely POSIX-compatible
+
+=back
+
+=head1 THE Linux FAMILY
+
+This includes both ordinary Linux and Android. Plain old Linux will
+match 'Linux'. Android will match both that and 'Android'.
+
+=head1 THE MicrosoftWindows FAMILY
+
+This includes any version of Windows and also includes things like
+Cygwin which run on top of it.
+
+=head1 THE DEC, Sun, and Apple FAMILIES
+
+These include any OS written by, respectively, DEC, Sun, and Apple.
+They exist because, while, eg, Mac OS Classic and Mac OS X are very
+different platforms, they do support some unique features - such as
+AppleScript.
+
+=head1 THE Realtime FAMILY
+
+This is for all real-time OSes.  So far, it only includes QNX.
+
+=head1 THE EBCDIC FAMILY
+
+OSes which use EBCDIC instead of ASCII.
+
+=head1 AUTHOR, COPYRIGHT and LICENCE
+
+Copyright 2008 - 2010 David Cantrell E<lt>F<david@cantrell.org.uk>E<gt>
+
+This documentation is free-as-in-speech.  It may be used,
+distributed and modified under the terms of the Creative Commons
+Attribution-Share Alike 2.0 UK: England & Wales License, whose
+text you may read at
+L<http://creativecommons.org/licenses/by-sa/2.0/uk/>.
+
+=head1 CONSPIRACY
+
+This documentation is also free-as-in-mason.
+
+=cut

--- a/lib/Unix/Uptime.pm
+++ b/lib/Unix/Uptime.pm
@@ -7,6 +7,7 @@ our $VERSION='0.3701';
 $VERSION = eval $VERSION;
 
 my %modules = (
+    cygwin    => 'Linux',
     freebsd   => 'BSD',
     dragonfly => 'BSD',
     linux     => 'Linux',


### PR DESCRIPTION
Cygwin has a /proc just like Linux (it is based on the Linux version in fact).

The first commit Devel::CheckOS could probably be trimmed a little bit, which is why I left it as a separate commit.  I can trim it if you prefer.

Thanks!
