### PR TITLE
support Solaris

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,4 +1,5 @@
-use lib inc; use Devel::AssertOS qw(Cygwin Linux FreeBSD DragonflyBSD OpenBSD MacOSX NetBSD);
+use lib inc;
+use Devel::AssertOS qw(Cygwin Linux FreeBSD DragonflyBSD OpenBSD MacOSX NetBSD Solaris);
 
 use strict;
 use warnings;

--- a/lib/Unix/Uptime.pm
+++ b/lib/Unix/Uptime.pm
@@ -14,6 +14,7 @@ my %modules = (
     openbsd   => 'BSD',
     darwin    => 'BSD',
     netbsd    => 'BSD',
+    solaris   => 'Solaris',
 );
 
 my $module = $modules{$^O}

--- a/lib/Unix/Uptime/Solaris.pm
+++ b/lib/Unix/Uptime/Solaris.pm
@@ -1,0 +1,49 @@
+package Unix::Uptime::Solaris;
+
+use warnings;
+use strict;
+
+our $VERSION='0.4000';
+$VERSION = eval $VERSION;
+
+sub uptime {
+    my $class = shift;
+    my $kstat_out = `/usr/bin/kstat -p unix:0:system_misc:boot_time`;
+    my $boot_time = (split(/\s+/, $kstat_out))[1];
+    my $uptime = time() - $boot_time;
+    return $uptime;
+}
+
+sub uptime_hires {
+    my $class = shift;
+    # short-circuit to the non-hires method.
+    # An XS function is needed if we want hires.
+    return $class->uptime();
+}
+
+sub load {
+    my $class = shift;
+
+    # For the magic number 256 see http://www.brendangregg.com/K9Toolkit/uptime
+    my @loads = map {
+        my $kstat_out = `/usr/bin/kstat -p unix:0:system_misc:avenrun_${_}min`;
+        (split(/\s+/, $kstat_out))[1] / 256;
+    } qw(1 5 15);
+    return map { sprintf("%.2f", $_); } @loads;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Unix::Uptime::Solaris - Solaris implementation of Unix::Uptime
+
+=head1 SEE ALSO
+
+L<Unix::Uptime>
+
+=cut
+
+# vim: set ft=perl sw=4 sts=4 et :


### PR DESCRIPTION
This is patch for #10

I don't support the hires methods as I don't need that. In this case I would prefer pure-Perl for simplicity. 