### PR TITLE
Debian kFreeBSD support

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -6,7 +6,7 @@ use warnings;
 
 use Module::Build 0.28;
 
-my $IS_BSD = $^O =~ /^(?:darwin|dragonfly|(?:free|open|net)bsd)$/;
+my $IS_BSD = $^O =~ /^(?:darwin|dragonfly|(?:gnukfree|free|open|net)bsd)$/;
 my $WANT_XS = $IS_BSD;
 $WANT_XS = 0 if $ENV{NO_XS};
 

--- a/lib/Unix/Uptime.pm
+++ b/lib/Unix/Uptime.pm
@@ -14,6 +14,7 @@ my %modules = (
     openbsd   => 'BSD',
     darwin    => 'BSD',
     netbsd    => 'BSD',
+    gnukfreebsd => 'BSD',
     solaris   => 'Solaris',
 );
 


### PR DESCRIPTION
Regarding #12 This works -ish.  003-load.t fails for me sometimes, I think due to a race condition:

```
t/003-load.t .......... 1/9 
#   Failed test at t/003-load.t line 20.
#          got: '0.08'
#     expected: '0.07'
# Looks like you failed 1 test of 9.
t/003-load.t .......... Dubious, test returned 1 (wstat 256, 0x100)
```

On my Debian kFreeBSD box you can also use the `Linux` driver, as the `/proc` file system is installed.  I am not sure if you can count on `/proc` being available, however.  Curiously using the `Linux` interface does not seem to suffer this race condition as often.